### PR TITLE
[MOB-501] Add an API for createPeerConnectionFactory

### DIFF
--- a/Mediasoup/Device.swift
+++ b/Mediasoup/Device.swift
@@ -9,6 +9,13 @@ open class Device {
 
     public var pcFactory: RTCPeerConnectionFactory { device.pcFactory }
 
+    /// Creates and returns a new RTCPeerConnectionFactory bound to `audioDevice`.
+    /// The device's own `pcFactory` and internal mediasoup state are NOT affected.
+    /// Use this to create media sources for in-person participants with separate microphones.
+    public func createPeerConnectionFactory(audioDevice: RTCAudioDevice? = nil) -> RTCPeerConnectionFactory {
+            return device.createPeerConnectionFactory(with: audioDevice)
+    }
+
     public init(audioDevice: RTCAudioDevice? = nil) {
         self.device = DeviceWrapper(audioDevice: audioDevice)
 	}

--- a/Mediasoup/Device.swift
+++ b/Mediasoup/Device.swift
@@ -9,9 +9,6 @@ open class Device {
 
     public var pcFactory: RTCPeerConnectionFactory { device.pcFactory }
 
-    /// Creates and returns a new RTCPeerConnectionFactory bound to `audioDevice`.
-    /// The device's own `pcFactory` and internal mediasoup state are NOT affected.
-    /// Use this to create media sources for in-person participants with separate microphones.
     public func createPeerConnectionFactory(audioDevice: RTCAudioDevice? = nil) -> RTCPeerConnectionFactory {
             return device.createPeerConnectionFactory(with: audioDevice)
     }

--- a/Mediasoup_Private/Device/DeviceWrapper.h
+++ b/Mediasoup_Private/Device/DeviceWrapper.h
@@ -17,6 +17,12 @@ typedef NS_ENUM(NSInteger, RTCIceTransportPolicy);
 
 - (instancetype _Nonnull)initWithAudioDevice:(id<RTCAudioDevice> _Nullable)audioDevice;
 
+/// Creates and returns a new RTCPeerConnectionFactory bound to audioDevice.
+/// Reuses the same video/audio encoder-decoder factory configuration as the device's primary factory.
+/// Use this to create additional factories for in-person participants with separate microphones.
+/// The device's own pcFactory and internal PeerConnection::Options are NOT modified.
+- (RTCPeerConnectionFactory *_Nonnull)createPeerConnectionFactoryWithAudioDevice:(id<RTCAudioDevice> _Nullable)audioDevice;
+
 - (BOOL)isLoaded;
 
 - (void)loadWithRouterRTPCapabilities:(NSString *_Nonnull)routerRTPCapabilities

--- a/Mediasoup_Private/Device/DeviceWrapper.h
+++ b/Mediasoup_Private/Device/DeviceWrapper.h
@@ -21,7 +21,8 @@ typedef NS_ENUM(NSInteger, RTCIceTransportPolicy);
 /// Reuses the same video/audio encoder-decoder factory configuration as the device's primary factory.
 /// Use this to create additional factories for in-person participants with separate microphones.
 /// The device's own pcFactory and internal PeerConnection::Options are NOT modified.
-- (RTCPeerConnectionFactory *_Nonnull)createPeerConnectionFactoryWithAudioDevice:(id<RTCAudioDevice> _Nullable)audioDevice;
+- (RTCPeerConnectionFactory *_Nonnull)createPeerConnectionFactoryWithAudioDevice:(id<RTCAudioDevice> _Nullable)audioDevice
+    NS_SWIFT_NAME(createPeerConnectionFactory(with:));
 
 - (BOOL)isLoaded;
 

--- a/Mediasoup_Private/Device/DeviceWrapper.mm
+++ b/Mediasoup_Private/Device/DeviceWrapper.mm
@@ -37,6 +37,37 @@
 #endif
 }
 
+- (RTCPeerConnectionFactory *)buildPeerConnectionFactoryWithAudioDevice:(nullable id<RTC_OBJC_TYPE(RTCAudioDevice)>)audioDevice
+    customAudioLog:(NSString *)customAudioLog
+    defaultAudioLog:(NSString *)defaultAudioLog {
+    auto audioEncoderFactory = webrtc::CreateBuiltinAudioEncoderFactory();
+    auto audioDecoderFactory = webrtc::CreateBuiltinAudioDecoderFactory();
+    auto videoEncoderFactory = std::make_unique<webrtc::ObjCVideoEncoderFactory>(
+        [[RTCDefaultVideoEncoderFactory alloc] init]
+    );
+    auto videoDecoderFactory = std::make_unique<webrtc::ObjCVideoDecoderFactory>(
+        [[RTCDefaultVideoDecoderFactory alloc] init]
+    );
+
+    auto pcFactoryBuilder = [[RTCPeerConnectionFactoryBuilder alloc] init];
+    [pcFactoryBuilder setAudioEncoderFactory:audioEncoderFactory];
+    [pcFactoryBuilder setAudioDecoderFactory:audioDecoderFactory];
+    [pcFactoryBuilder setVideoEncoderFactory:std::move(videoEncoderFactory)];
+    [pcFactoryBuilder setVideoDecoderFactory:std::move(videoDecoderFactory)];
+
+    rtc::scoped_refptr<webrtc::AudioDeviceModule> audio_device_module;
+    if (audioDevice) {
+        NSLog(@"%@", customAudioLog);
+        audio_device_module = webrtc::CreateAudioDeviceModule(audioDevice);
+    } else {
+        NSLog(@"%@", defaultAudioLog);
+        audio_device_module = [self audioDeviceModule];
+    }
+    [pcFactoryBuilder setAudioDeviceModule:audio_device_module];
+
+    return [pcFactoryBuilder createPeerConnectionFactory];
+}
+
 - (instancetype)init {
     return [self initWithAudioDevice:nil];
 }
@@ -45,33 +76,9 @@
     self = [super init];
     if (self != nil) {
         _device = new mediasoupclient::Device();
-
-        auto audioEncoderFactory = webrtc::CreateBuiltinAudioEncoderFactory();
-        auto audioDecoderFactory = webrtc::CreateBuiltinAudioDecoderFactory();
-        auto videoEncoderFactory = std::make_unique<webrtc::ObjCVideoEncoderFactory>(
-            [[RTCDefaultVideoEncoderFactory alloc] init]
-        );
-        auto videoDecoderFactory = std::make_unique<webrtc::ObjCVideoDecoderFactory>(
-            [[RTCDefaultVideoDecoderFactory alloc] init]
-        );
-
-        auto pcFactoryBuilder = [[RTCPeerConnectionFactoryBuilder alloc] init];
-        [pcFactoryBuilder setAudioEncoderFactory:audioEncoderFactory];
-        [pcFactoryBuilder setAudioDecoderFactory:audioDecoderFactory];
-        [pcFactoryBuilder setVideoEncoderFactory:std::move(videoEncoderFactory)];
-        [pcFactoryBuilder setVideoDecoderFactory:std::move(videoDecoderFactory)];
-    
-        rtc::scoped_refptr<webrtc::AudioDeviceModule> audio_device_module;
-        if (audioDevice) {
-            NSLog(@" -----------> Custom audio module applied");
-            audio_device_module = webrtc::CreateAudioDeviceModule(audioDevice);;
-          } else {
-            NSLog(@" -----------> Default audio module applied");
-            audio_device_module = [self audioDeviceModule];
-          }
-        [pcFactoryBuilder setAudioDeviceModule:audio_device_module];
-        
-        self.pcFactory = [pcFactoryBuilder createPeerConnectionFactory];
+        self.pcFactory = [self buildPeerConnectionFactoryWithAudioDevice:audioDevice
+            customAudioLog:@" -----------> Custom audio module applied"
+            defaultAudioLog:@" -----------> Default audio module applied"];
         _pcOptions = new mediasoupclient::PeerConnection::Options();
         _pcOptions->factory = self.pcFactory.nativeFactory.get();
     }
@@ -276,32 +283,9 @@
 }
 
 - (RTCPeerConnectionFactory *)createPeerConnectionFactoryWithAudioDevice:(nullable id<RTC_OBJC_TYPE(RTCAudioDevice)>)audioDevice {
-    auto audioEncoderFactory = webrtc::CreateBuiltinAudioEncoderFactory();
-    auto audioDecoderFactory = webrtc::CreateBuiltinAudioDecoderFactory();
-    auto videoEncoderFactory = std::make_unique<webrtc::ObjCVideoEncoderFactory>(
-        [[RTCDefaultVideoEncoderFactory alloc] init]
-    );
-    auto videoDecoderFactory = std::make_unique<webrtc::ObjCVideoDecoderFactory>(
-        [[RTCDefaultVideoDecoderFactory alloc] init]
-    );
-
-    auto pcFactoryBuilder = [[RTCPeerConnectionFactoryBuilder alloc] init];
-    [pcFactoryBuilder setAudioEncoderFactory:audioEncoderFactory];
-    [pcFactoryBuilder setAudioDecoderFactory:audioDecoderFactory];
-    [pcFactoryBuilder setVideoEncoderFactory:std::move(videoEncoderFactory)];
-    [pcFactoryBuilder setVideoDecoderFactory:std::move(videoDecoderFactory)];
-
-    rtc::scoped_refptr<webrtc::AudioDeviceModule> audio_device_module;
-    if (audioDevice) {
-        NSLog(@" -----------> InPerson: Custom audio module applied for new factory");
-        audio_device_module = webrtc::CreateAudioDeviceModule(audioDevice);
-    } else {
-        NSLog(@" -----------> InPerson: Default audio module applied for new factory");
-        audio_device_module = [self audioDeviceModule];
-    }
-    [pcFactoryBuilder setAudioDeviceModule:audio_device_module];
-
-    return [pcFactoryBuilder createPeerConnectionFactory];
+    return [self buildPeerConnectionFactoryWithAudioDevice:audioDevice
+        customAudioLog:@" -----------> InPerson: Custom audio module applied for new factory"
+        defaultAudioLog:@" -----------> InPerson: Default audio module applied for new factory"];
 }
 
 #pragma MARK - Private methods

--- a/Mediasoup_Private/Device/DeviceWrapper.mm
+++ b/Mediasoup_Private/Device/DeviceWrapper.mm
@@ -275,6 +275,35 @@
 	}
 }
 
+- (RTCPeerConnectionFactory *)createPeerConnectionFactoryWithAudioDevice:(nullable id<RTC_OBJC_TYPE(RTCAudioDevice)>)audioDevice {
+    auto audioEncoderFactory = webrtc::CreateBuiltinAudioEncoderFactory();
+    auto audioDecoderFactory = webrtc::CreateBuiltinAudioDecoderFactory();
+    auto videoEncoderFactory = std::make_unique<webrtc::ObjCVideoEncoderFactory>(
+        [[RTCDefaultVideoEncoderFactory alloc] init]
+    );
+    auto videoDecoderFactory = std::make_unique<webrtc::ObjCVideoDecoderFactory>(
+        [[RTCDefaultVideoDecoderFactory alloc] init]
+    );
+
+    auto pcFactoryBuilder = [[RTCPeerConnectionFactoryBuilder alloc] init];
+    [pcFactoryBuilder setAudioEncoderFactory:audioEncoderFactory];
+    [pcFactoryBuilder setAudioDecoderFactory:audioDecoderFactory];
+    [pcFactoryBuilder setVideoEncoderFactory:std::move(videoEncoderFactory)];
+    [pcFactoryBuilder setVideoDecoderFactory:std::move(videoDecoderFactory)];
+
+    rtc::scoped_refptr<webrtc::AudioDeviceModule> audio_device_module;
+    if (audioDevice) {
+        NSLog(@" -----------> InPerson: Custom audio module applied for new factory");
+        audio_device_module = webrtc::CreateAudioDeviceModule(audioDevice);
+    } else {
+        NSLog(@" -----------> InPerson: Default audio module applied for new factory");
+        audio_device_module = [self audioDeviceModule];
+    }
+    [pcFactoryBuilder setAudioDeviceModule:audio_device_module];
+
+    return [pcFactoryBuilder createPeerConnectionFactory];
+}
+
 #pragma MARK - Private methods
 
 - (mediasoupclient::PeerConnection::Options)pcOptionsWithICEServers:(NSString *_Nullable)iceServers


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add ability to create additional peer-connection factories tied to an optional audio device, allowing separate handling of multiple audio sources.
  * New factories reuse existing encoder/decoder configuration and preserve current factory/state behavior to maintain backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->